### PR TITLE
File List Android

### DIFF
--- a/android/src/main/java/com/aerobotics/DjiMobile/CameraControlNative.java
+++ b/android/src/main/java/com/aerobotics/DjiMobile/CameraControlNative.java
@@ -16,9 +16,8 @@ import dji.keysdk.CameraKey;
 import dji.keysdk.DJIKey;
 import dji.keysdk.callback.GetCallback;
 import dji.keysdk.callback.SetCallback;
+import dji.keysdk.callback.ActionCallback;
 import dji.sdk.sdkmanager.DJISDKManager;
-
-
 
 public class CameraControlNative extends ReactContextBaseJavaModule {
     public CameraControlNative(ReactApplicationContext reactContext) {
@@ -165,6 +164,23 @@ public class CameraControlNative extends ReactContextBaseJavaModule {
                 promise.reject("CameraControlNative: Failed to set exposure mode");
             }
         });
+    }
+
+    @ReactMethod
+    public void stopRecording(final Promise promise) {
+      DJIKey stopRecordingKey = CameraKey.create(CameraKey.STOP_RECORD_VIDEO);
+      DJISDKManager.getInstance().getKeyManager().performAction(stopRecordingKey, new ActionCallback() {
+        @Override
+        public void onSuccess() {
+            Log.i("REACT", "CameraControlNative: stopRecording ran successfully");
+            promise.resolve("CameraControlNative: stopRecording ran successfully");
+        }
+
+        @Override
+        public void onFailure(@NonNull DJIError djiError) {
+            promise.reject("CameraControlNative: stopRecording failed to stop recording");
+        }
+      });
     }
 
 }

--- a/android/src/main/java/com/aerobotics/DjiMobile/DJIMedia.java
+++ b/android/src/main/java/com/aerobotics/DjiMobile/DJIMedia.java
@@ -64,7 +64,7 @@ public class DJIMedia  {
     camera.setMode(SettingsDefinitions.CameraMode.MEDIA_DOWNLOAD, new CommonCallbacks.CompletionCallback() {
       @Override
       public void onResult(DJIError djiError) {
-        if (error == null) {
+        if (djiError == null) {
           getFileList();
         } else {
           promise.reject(djiError.toString(), djiError.getDescription());

--- a/android/src/main/java/com/aerobotics/DjiMobile/DJIMedia.java
+++ b/android/src/main/java/com/aerobotics/DjiMobile/DJIMedia.java
@@ -24,6 +24,7 @@ import dji.sdk.media.MediaManager;
 import dji.sdk.media.MediaFile;
 import dji.sdk.sdkmanager.DJISDKManager;
 import dji.sdk.products.Aircraft;
+import dji.sdk.base.BaseProduct;
 
 public class DJIMedia  {
   private Promise promise;
@@ -40,12 +41,21 @@ public class DJIMedia  {
   };
 
   DJIMedia(){
-    camera = ((Aircraft) DJISDKManager.getInstance().getProduct()).getCamera();
-    mediaManager = camera.getMediaManager();
+
   }
 
-  public void getFileList(final Promise promise) {
+  public void getFileList(final Promise promise, BaseProduct baseProduct) {
     this.promise = promise;
+
+    Aircraft aircraft =  (Aircraft) baseProduct;
+
+    camera = aircraft.getCamera();
+    if (camera == null){
+      promise.reject("No camera connected");
+      return;
+    }
+    System.out.println("dronecha got camera");
+    mediaManager = camera.getMediaManager();
 
     initMediaManager();
   }
@@ -56,9 +66,12 @@ public class DJIMedia  {
       @Override
       public void onResult(DJIError error) {
         if (error == null) {
+          System.out.println("dronecha set mode");
+
           getFileList();
         } else {
           promise.reject("Set cameraMode failed");
+          return;
         }
       }
     });

--- a/android/src/main/java/com/aerobotics/DjiMobile/DJIMedia.java
+++ b/android/src/main/java/com/aerobotics/DjiMobile/DJIMedia.java
@@ -54,7 +54,6 @@ public class DJIMedia  {
       promise.reject("No camera connected");
       return;
     }
-    System.out.println("dronecha got camera");
     mediaManager = camera.getMediaManager();
 
     initMediaManager();
@@ -66,8 +65,6 @@ public class DJIMedia  {
       @Override
       public void onResult(DJIError error) {
         if (error == null) {
-          System.out.println("dronecha set mode");
-
           getFileList();
         } else {
           promise.reject("Set cameraMode failed");

--- a/android/src/main/java/com/aerobotics/DjiMobile/DJIMedia.java
+++ b/android/src/main/java/com/aerobotics/DjiMobile/DJIMedia.java
@@ -63,7 +63,7 @@ public class DJIMedia  {
     mediaManager.addUpdateFileListStateListener(this.updateFileListStateListener);
     camera.setMode(SettingsDefinitions.CameraMode.MEDIA_DOWNLOAD, new CommonCallbacks.CompletionCallback() {
       @Override
-      public void onResult(DJIError error) {
+      public void onResult(DJIError djiError) {
         if (error == null) {
           getFileList();
         } else {

--- a/android/src/main/java/com/aerobotics/DjiMobile/DJIMedia.java
+++ b/android/src/main/java/com/aerobotics/DjiMobile/DJIMedia.java
@@ -67,7 +67,7 @@ public class DJIMedia  {
         if (error == null) {
           getFileList();
         } else {
-          promise.reject("Set cameraMode failed");
+          promise.reject(djiError.toString(), djiError.getDescription());
           return;
         }
       }

--- a/android/src/main/java/com/aerobotics/DjiMobile/DJIMedia.java
+++ b/android/src/main/java/com/aerobotics/DjiMobile/DJIMedia.java
@@ -1,0 +1,119 @@
+package com.aerobotics.DjiMobile;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import dji.common.camera.SettingsDefinitions;
+import dji.common.error.DJIError;
+import dji.common.util.CommonCallbacks;
+import dji.sdk.camera.Camera;
+import dji.sdk.media.DownloadListener;
+import dji.sdk.media.MediaManager;
+import dji.sdk.media.MediaFile;
+import dji.sdk.sdkmanager.DJISDKManager;
+import dji.sdk.products.Aircraft;
+
+public class DJIMedia  {
+  private Promise promise;
+  private MediaManager.FileListState currentFileListState = MediaManager.FileListState.UNKNOWN;
+  private MediaManager mediaManager;
+  private Camera camera;
+  private List<MediaFile> mediaFileList = new ArrayList<MediaFile>();
+
+  private MediaManager.FileListStateListener updateFileListStateListener = new MediaManager.FileListStateListener() {
+    @Override
+    public void onFileListStateChange(MediaManager.FileListState state) {
+      currentFileListState = state;
+    }
+  };
+
+  DJIMedia(){
+    camera = ((Aircraft) DJISDKManager.getInstance().getProduct()).getCamera();
+    mediaManager = camera.getMediaManager();
+  }
+
+  public void getFileList(final Promise promise) {
+    this.promise = promise;
+
+    initMediaManager();
+  }
+
+  private void initMediaManager() {
+    mediaManager.addUpdateFileListStateListener(this.updateFileListStateListener);
+    camera.setMode(SettingsDefinitions.CameraMode.MEDIA_DOWNLOAD, new CommonCallbacks.CompletionCallback() {
+      @Override
+      public void onResult(DJIError error) {
+        if (error == null) {
+          getFileList();
+        } else {
+          promise.reject("Set cameraMode failed");
+        }
+      }
+    });
+    return;
+  }
+
+  public void getFileList() {
+
+    if ((currentFileListState == MediaManager.FileListState.SYNCING) || (currentFileListState == MediaManager.FileListState.DELETING)){
+      promise.reject("Media manager is busy");
+
+    } else{
+      System.out.println("Refresh file list");
+
+      mediaManager.refreshFileListOfStorageLocation(SettingsDefinitions.StorageLocation.SDCARD, new CommonCallbacks.CompletionCallback() {
+        @Override
+        public void onResult(DJIError djiError) {
+          if (null == djiError) {
+            //Reset data
+            if (currentFileListState != MediaManager.FileListState.INCOMPLETE) {
+              mediaFileList.clear();
+            }
+
+            mediaFileList = mediaManager.getSDCardFileListSnapshot();
+
+            // Sort to get latest file first
+            Collections.sort(mediaFileList, new Comparator<MediaFile>() {
+              @Override
+              public int compare(MediaFile lhs, MediaFile rhs) {
+                if (lhs.getTimeCreated() < rhs.getTimeCreated()) {
+                  return 1;
+                } else if (lhs.getTimeCreated() > rhs.getTimeCreated()) {
+                  return -1;
+                }
+                return 0;
+              }
+            });
+
+            WritableArray params = Arguments.createArray();
+            for (MediaFile m : mediaFileList){
+              WritableMap file = Arguments.createMap();
+              file.putString("fileName", m.getFileName());
+              file.putDouble("timeCreatedAt", m.getTimeCreated());
+              file.putDouble("fileSize", m.getFileSize());
+              params.pushMap(file);
+            }
+
+            System.out.println("Get Media File List Success");
+            promise.resolve(params);
+          } else {
+            System.out.println("Get Media File List Failed");
+            promise.reject(djiError.toString(), djiError.getDescription());
+          }
+        }
+      });
+    }
+  }
+}

--- a/android/src/main/java/com/aerobotics/DjiMobile/DJIMobile.java
+++ b/android/src/main/java/com/aerobotics/DjiMobile/DJIMobile.java
@@ -107,18 +107,6 @@ public class DJIMobile extends ReactContextBaseJavaModule {
     registerAppInternal(bridgeIp, promise);
   }
 
-  @ReactMethod
-  public void getFileList(final Promise promise) {
-    System.out.println("dronecha get file list");
-
-    DJIMedia m = new DJIMedia();
-    if (product == null){
-      promise.reject("No product connected");
-    } else {
-      m.getFileList(promise, product);
-    }
-  }
-
   public void registerAppInternal(final String bridgeIp, final Promise promise) {
     final DJISDKManager djisdkManager = DJISDKManager.getInstance();
     djisdkManager.registerApp(reactContext, new DJISDKManager.SDKManagerCallback() {
@@ -163,8 +151,14 @@ public class DJIMobile extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void getFileList(final Promise promise) {
+    System.out.println("dronecha get file list");
+
     DJIMedia m = new DJIMedia();
-    m.getFileList(promise);
+    if (product == null){
+      promise.reject("No product connected");
+    } else {
+      m.getFileList(promise, product);
+    }
   }
 
   @ReactMethod

--- a/android/src/main/java/com/aerobotics/DjiMobile/DJIMobile.java
+++ b/android/src/main/java/com/aerobotics/DjiMobile/DJIMobile.java
@@ -147,6 +147,12 @@ public class DJIMobile extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void getFileList(final Promise promise) {
+    DJIMedia m = new DJIMedia();
+    m.getFileList(promise);
+  }
+
+  @ReactMethod
   public void setCollisionAvoidanceEnabled(final Boolean enabled, final Promise promise) {
     DJIKey collisionAvoidanceKey = FlightControllerKey.createFlightAssistantKey(FlightControllerKey.COLLISION_AVOIDANCE_ENABLED);
     DJISDKManager.getInstance().getKeyManager().setValue(collisionAvoidanceKey, enabled, new SetCallback() {

--- a/android/src/main/java/com/aerobotics/DjiMobile/DJIMobile.java
+++ b/android/src/main/java/com/aerobotics/DjiMobile/DJIMobile.java
@@ -137,8 +137,6 @@ public class DJIMobile extends ReactContextBaseJavaModule {
 
       @Override
       public void onProductConnect(BaseProduct baseProduct) {
-        System.out.println("dronecha got product");
-
         product = baseProduct;
       }
 
@@ -151,8 +149,6 @@ public class DJIMobile extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void getFileList(final Promise promise) {
-    System.out.println("dronecha get file list");
-
     DJIMedia m = new DJIMedia();
     if (product == null){
       promise.reject("No product connected");

--- a/android/src/main/java/com/aerobotics/DjiMobile/DJIMobile.java
+++ b/android/src/main/java/com/aerobotics/DjiMobile/DJIMobile.java
@@ -75,6 +75,7 @@ public class DJIMobile extends ReactContextBaseJavaModule {
 
   ; // This must only be initialized once the SDK has registered, as it uses the SDK
   private SdkEventHandler sdkEventHandler;
+  private BaseProduct product;
 
 //  private Observer newMediaFileObserver = new Observer() {
 //    @Override
@@ -106,6 +107,18 @@ public class DJIMobile extends ReactContextBaseJavaModule {
     registerAppInternal(bridgeIp, promise);
   }
 
+  @ReactMethod
+  public void getFileList(final Promise promise) {
+    System.out.println("dronecha get file list");
+
+    DJIMedia m = new DJIMedia();
+    if (product == null){
+      promise.reject("No product connected");
+    } else {
+      m.getFileList(promise, product);
+    }
+  }
+
   public void registerAppInternal(final String bridgeIp, final Promise promise) {
     final DJISDKManager djisdkManager = DJISDKManager.getInstance();
     djisdkManager.registerApp(reactContext, new DJISDKManager.SDKManagerCallback() {
@@ -131,12 +144,14 @@ public class DJIMobile extends ReactContextBaseJavaModule {
 
       @Override
       public void onProductDisconnect() {
-        // TODO
+        product = null;
       }
 
       @Override
       public void onProductConnect(BaseProduct baseProduct) {
-        // TODO
+        System.out.println("dronecha got product");
+
+        product = baseProduct;
       }
 
       @Override

--- a/index.js
+++ b/index.js
@@ -159,8 +159,8 @@ const DJIMobileWrapper = {
       await DJIMobile.stopEventListener('CameraDidGenerateNewMediaFile');
     }
   },
-  getFileList: () => {
-    return DJIMobile.getFileList();
+  getFileList: async () => {
+    return await DJIMobile.getFileList();
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -159,7 +159,9 @@ const DJIMobileWrapper = {
       await DJIMobile.stopEventListener('CameraDidGenerateNewMediaFile');
     }
   },
-
+  getFileList: () => {
+    return DJIMobile.getFileList();
+  }
 };
 
 export default DJIMobileWrapper;

--- a/lib/CameraControl/index.js
+++ b/lib/CameraControl/index.js
@@ -96,6 +96,10 @@ const CameraControl = {
   setExposureMode: async (exposureMode: ExposureMode) => {
     await CameraControlNative.setExposureMode(exposureModes[exposureMode][Platform.OS]);
   },
+
+  stopRecording: async () => {
+  return await CameraControlNative.stopRecording();
+  }
 };
 
 export default CameraControl;


### PR DESCRIPTION
The  newMediaFileListener is really slow to detect new files.  I have seen it take minutes after recording stopped.  Not sure why.

Here is an implementation of listing all of the files on the SD for Android.

There is a bug in it though that you might have some insight on.  I need the product to get the camera.  You get the product (which is an Aircraft) from the onProductConnect callback.  Unfortunately this callback happens after SDKEvent.ProductConnection callback.  So if you call getFileList when you get the callback from SDKEvent it will fail with no product.

It is easy to workaround with a delay, but that is not fantastic:
      setTimeout(async () => {
        const fileList = await DJIMobileWrapper.getFileList();
        console.log("JSON.stringify(fileList));
      },1000);

