### PR TITLE
Add a delay when sending initial value event

### DIFF
--- a/android/src/main/java/com/aerobotics/DjiMobile/SdkEventHandler.java
+++ b/android/src/main/java/com/aerobotics/DjiMobile/SdkEventHandler.java
@@ -150,8 +150,7 @@ public class SdkEventHandler {
 
       @Override
       public void onFailure(@NonNull DJIError djiError) {
-        Log.d("REACT", djiError.getDescription());
-        // An initial value couldn't be gotten
+          // An initial value couldn't be gotten
       }
     });
   }

--- a/android/src/main/java/com/aerobotics/DjiMobile/SdkEventHandler.java
+++ b/android/src/main/java/com/aerobotics/DjiMobile/SdkEventHandler.java
@@ -2,6 +2,7 @@ package com.aerobotics.DjiMobile;
 
 
 import android.os.Handler;
+import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Log;
@@ -82,6 +83,10 @@ public class SdkEventHandler {
   private class EventInfo {
     String key;
     EventType eventType;
+  }
+
+  public SdkEventHandler() {
+    handler = new Handler(Looper.getMainLooper());
   }
 
   public Object startEventListener(final SDKEvent sdkEvent, final EventListener eventListener) {

--- a/android/src/main/java/com/aerobotics/DjiMobile/SdkEventHandler.java
+++ b/android/src/main/java/com/aerobotics/DjiMobile/SdkEventHandler.java
@@ -1,8 +1,10 @@
 package com.aerobotics.DjiMobile;
 
 
+import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.util.Log;
 
 import java.util.HashMap;
 import java.util.Observable;
@@ -75,6 +77,7 @@ interface EventListener {
 public class SdkEventHandler {
 
   private CameraEventDelegate cameraEventDelegate = new CameraEventDelegate();
+  private Handler handler;
 
   private class EventInfo {
     String key;
@@ -133,15 +136,21 @@ public class SdkEventHandler {
    * This allows us to get the initial value for a DJI key when starting a listener, as sometimes the initial value is only sent through
    * when a new event occurs and calls the listener.
    */
-  private void getInitialDJIKeyValue(DJIKey key, final EventListener eventListener) {
+  private void getInitialDJIKeyValue(final DJIKey key, final EventListener eventListener) {
     KeyManager.getInstance().getValue((DJIKey)key, new GetCallback() {
       @Override
-      public void onSuccess(@NonNull Object value) {
-        eventListener.onValueChange(null, value);
+      public void onSuccess(@NonNull final Object value) {
+        handler.postDelayed(new Runnable() {
+          @Override
+          public void run() {
+            eventListener.onValueChange(null, value);
+          }
+        }, 500);
       }
 
       @Override
       public void onFailure(@NonNull DJIError djiError) {
+        Log.d("REACT", djiError.getDescription());
         // An initial value couldn't be gotten
       }
     });


### PR DESCRIPTION
The event gets sent to early and doesn't get picked up in the JS listener.
Ideally this should get fixed in JS but this is a quick work around.