### PR TITLE
fix(iOS): Fix camera delegate not connecting to camera correctly every time.

### DIFF
--- a/ios/DJICameraDelegateSender.swift
+++ b/ios/DJICameraDelegateSender.swift
@@ -34,13 +34,12 @@ class DJICameraDelegateSender: NSObject, DJICameraDelegate {
     super.init()
     
     let cameraConnectedKey = DJICameraKey(param: DJIParamConnection)!
-    
+        
     DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
       // First check if the camera is already connected
       DJISDKManager.keyManager()?.getValueFor(cameraConnectedKey, withCompletion: { (value: DJIKeyedValue?, error: Error?) in
         if (error != nil) {
-          print("Camera Delegate Error:")
-          print(error!.localizedDescription)
+          NSLog("Camera delegate error: %@", error?.localizedDescription ?? "No error" )
         }
         if let isCameraConnected = value?.boolValue {
           if (isCameraConnected) {
@@ -56,10 +55,13 @@ class DJICameraDelegateSender: NSObject, DJICameraDelegate {
       DJISDKManager.keyManager()?.startListeningForChanges(on: cameraConnectedKey, withListener: self) { (oldValue: DJIKeyedValue?, newValue: DJIKeyedValue?) in
         if let connected = newValue?.boolValue {
           if (connected == true) {
-            guard let camera = DJISDKManager.product()?.camera else {
-              return
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+              guard let camera = DJISDKManager.product()?.camera else {
+                NSLog("Camera connected but cannot access!")
+                return
+              }
+              camera.delegate = self
             }
-            camera.delegate = self
           }
         }
       }

--- a/ios/ReactNativeDjiMobile.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/ReactNativeDjiMobile.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
When turning on the remote when the app is already running, the camera delegate could fail to connect, as the camera requires some time before it is accessible.