### PR TITLE
Increase delay before setting camera callbacks (to ensure product connected)

### DIFF
--- a/android/src/main/java/com/aerobotics/DjiMobile/CameraEventDelegate.java
+++ b/android/src/main/java/com/aerobotics/DjiMobile/CameraEventDelegate.java
@@ -92,7 +92,7 @@ public class CameraEventDelegate implements SystemState.Callback, MediaFile.Call
               camera.setMediaFileCallback(cameraDelegateSenderInstance);
             }
         }
-      }, 3000);
+      }, 6000);
 
     }
   }


### PR DESCRIPTION
This is just a hotfix, a more robust solution will need to be implemented