### PR TITLE
Fix: Enable video captions argument should be bool

### DIFF
--- a/android/src/main/java/com/aerobotics/DjiMobile/CameraControlNative.java
+++ b/android/src/main/java/com/aerobotics/DjiMobile/CameraControlNative.java
@@ -421,7 +421,7 @@ public class CameraControlNative extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void setVideoCaptionsEnabled(String enabled, final Promise promise) {
+    public void setVideoCaptionsEnabled(Boolean enabled, final Promise promise) {
         DJIKey videoCaptionKey = CameraKey.create(CameraKey.VIDEO_CAPTION_ENABLED);
         DJISDKManager.getInstance().getKeyManager().setValue(videoCaptionKey, enabled, new SetCallback() {
             @Override


### PR DESCRIPTION
`setVideoCaptionEnabled` requires a bool argument, but in one method definition, the argument was a `string`. 

@MikeWoots @arosendorff  how can we test this to know this is working? 