### PR TITLE
feat: add android method to set video standard

### DIFF
--- a/android/src/main/java/com/aerobotics/DjiMobile/CameraControlNative.java
+++ b/android/src/main/java/com/aerobotics/DjiMobile/CameraControlNative.java
@@ -470,6 +470,22 @@ public class CameraControlNative extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void setVideoStandard(String videoStandard, final Promise promise) {
+        DJIKey videoStandardKey = CameraKey.create(CameraKey.VIDEO_STANDARD);
+        DJISDKManager.getInstance().getKeyManager().setValue(videoStandardKey, SettingsDefinitions.VideoStandard.valueOf(videoStandard), new SetCallback() {
+            @Override
+            public void onSuccess() {
+                promise.resolve("setVideoStandard: focus mode set successfully");
+            }
+
+            @Override
+            public void onFailure(@NonNull DJIError djiError) {
+                promise.reject(new Throwable("setVideoStandard error: " + djiError.getDescription()));
+            }
+        });
+    }
+
+    @ReactMethod
     public void getFocusStatus(final Promise promise) {
         DJIKey focusStatusKey = CameraKey.create(CameraKey.FOCUS_STATUS);
         DJISDKManager.getInstance().getKeyManager().getValue(focusStatusKey, new GetCallback() {

--- a/lib/CameraControl/index.js
+++ b/lib/CameraControl/index.js
@@ -228,7 +228,7 @@ const CameraControl = {
   },
   isRecording: async () => {
     return await CameraControlNative.isRecording();
-  },
+  }
 };
 
 export default CameraControl;

--- a/lib/CameraControl/index.js
+++ b/lib/CameraControl/index.js
@@ -135,6 +135,14 @@ const focusModes = Object.freeze({
   'afc': 'AFC',
 });
 
+type VideoStandard = 'pal' | 'ntsc' | 'unknown'
+
+const videoStandards = Object.freeze({
+  'pal': 'PAL',
+  'ntsc': 'NTSC',
+  'unknown': 'UNKNOWN',
+});
+
 const CameraControl = {
 
   setPhotoAspectRatio: async (photoAspectRatio: PhotoAspectRatio) => {
@@ -206,6 +214,9 @@ const CameraControl = {
   setFocusTarget: async (x: number, y: number) => {
     return await CameraControlNative.setFocusTarget(x, y);
   },
+  setVideoStandard: async (videoStandard: VideoStandard) => {
+    return await CameraControlNative.setVideoStandard(videoStandards[videoStandard]);
+  },
   getFocusStatus: async () => {
     return await CameraControlNative.getFocusStatus();
   },
@@ -217,7 +228,7 @@ const CameraControl = {
   },
   isRecording: async () => {
     return await CameraControlNative.isRecording();
-  }
+  },
 };
 
 export default CameraControl;


### PR DESCRIPTION
Method to set video standard to 'pal', 'ntsc' or 'unknown'. 

Requested by @MikeWoots. 

✅  Tested with Matrice using AVO dev drawer