### PR TITLE
Feat: add method set/get video standard

### DIFF
--- a/android/src/main/java/com/aerobotics/DjiMobile/CameraControlNative.java
+++ b/android/src/main/java/com/aerobotics/DjiMobile/CameraControlNative.java
@@ -486,6 +486,24 @@ public class CameraControlNative extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void getVideoStandard(final Promise promise) {
+        DJIKey videoStandardKey = CameraKey.create(CameraKey.VIDEO_STANDARD);
+        DJISDKManager.getInstance().getKeyManager().getValue(videoStandardKey, new GetCallback() {
+            @Override
+            public void onSuccess(@NonNull Object value) {
+                if (value instanceof SettingsDefinitions.VideoStandard) {
+                    promise.resolve(((SettingsDefinitions.VideoStandard) value).name());
+                }
+            }
+
+            @Override
+            public void onFailure(@NonNull DJIError djiError) {
+                promise.reject(new Throwable("getVideoStandard error: " + djiError.getDescription()));
+            }
+        });
+    }
+
+    @ReactMethod
     public void getFocusStatus(final Promise promise) {
         DJIKey focusStatusKey = CameraKey.create(CameraKey.FOCUS_STATUS);
         DJISDKManager.getInstance().getKeyManager().getValue(focusStatusKey, new GetCallback() {

--- a/android/src/main/java/com/aerobotics/DjiMobile/CameraControlNative.java
+++ b/android/src/main/java/com/aerobotics/DjiMobile/CameraControlNative.java
@@ -475,7 +475,7 @@ public class CameraControlNative extends ReactContextBaseJavaModule {
         DJISDKManager.getInstance().getKeyManager().setValue(videoStandardKey, SettingsDefinitions.VideoStandard.valueOf(videoStandard), new SetCallback() {
             @Override
             public void onSuccess() {
-                promise.resolve("setVideoStandard: focus mode set successfully");
+                promise.resolve("setVideoStandard: video standard set successfully");
             }
 
             @Override

--- a/lib/CameraControl/index.js
+++ b/lib/CameraControl/index.js
@@ -217,6 +217,9 @@ const CameraControl = {
   setVideoStandard: async (videoStandard: VideoStandard) => {
     return await CameraControlNative.setVideoStandard(videoStandards[videoStandard]);
   },
+  getVideoStandard: async () => {
+    return await CameraControlNative.getVideoStandard();
+  },
   getFocusStatus: async () => {
     return await CameraControlNative.getFocusStatus();
   },


### PR DESCRIPTION
### Summary

Add the methods:

- `setVideoStandard`
- `getVideoStandard`

### Testing

✅  Tested with the Matrice

### A Closing Remark

`setVideoStandard` returns immediately, but it seems that it puts the camera into some sort of reboot state after its call. This means that, any camera method called shortly after this does not succeed, and I could not find a method which returns when the camera is back in a nominal state 😢 