### PR TITLE
Return drone model enum name

### DIFF
--- a/android/src/main/java/com/aerobotics/DjiMobile/DJIMobile.java
+++ b/android/src/main/java/com/aerobotics/DjiMobile/DJIMobile.java
@@ -916,7 +916,7 @@ public class DJIMobile extends ReactContextBaseJavaModule {
         @Override
         public void onSuccess(@NonNull Object value) {
           if (value instanceof Model) {
-            promise.resolve(((Model) value).getDisplayName());
+            promise.resolve(((Model) value).name());
           }
         }
 


### PR DESCRIPTION
The method `DjiMobile.getModelName()` was returning the display name of the drone model name, which doesn't seem to exist in the documentation. However, the enum names are in the docs. 

Thus, making a small update to return the enum name, rather than the unknown display name. 

✅  Tested

@MikeWoots @arosendorff viz. 