### PR TITLE
Fix: Home location altitude firing with negligible changes

### DIFF
--- a/android/src/main/java/com/aerobotics/DjiMobile/DJIMobile.java
+++ b/android/src/main/java/com/aerobotics/DjiMobile/DJIMobile.java
@@ -559,15 +559,33 @@ public class DJIMobile extends ReactContextBaseJavaModule {
     startEventListener(SDKEvent.TakeoffLocationAltitude, new EventListener() {
       @Override
       public void onValueChange(@Nullable Object oldValue, @Nullable Object newValue) {
-        if (newValue instanceof Float) {
-          Float takeoffLocationAltitude = (Float) newValue;
-          if (!takeoffLocationAltitude.isNaN() && !takeoffLocationAltitude.isInfinite()) {
+        if (!isObjectValidFloatValue(newValue)) {
+          return;
+        }
+        Float takeoffLocationAltitude = (Float) newValue;
+
+        if (!isObjectValidFloatValue(oldValue)) {
+          homeLocation[2] = Double.valueOf(takeoffLocationAltitude);
+          sendAircraftHomeLocationEvent(homeLocation[0], homeLocation[1], homeLocation[2]);
+        } else {
+          // Only send update if new value is significantly (0.5m) different to old value
+          Float oldTakeoffLocationAltitude = (Float) oldValue;
+          Float altitudeDelta = Math.abs(oldTakeoffLocationAltitude - takeoffLocationAltitude);
+          if (altitudeDelta > 0.25) {
             homeLocation[2] = Double.valueOf(takeoffLocationAltitude);
             sendAircraftHomeLocationEvent(homeLocation[0], homeLocation[1], homeLocation[2]);
           }
         }
       }
     });
+  }
+
+  private boolean isObjectValidFloatValue(@Nullable Object value) {
+    if (!(value instanceof Float)) {
+      return false;
+    }
+    Float valueAsFloat = (Float) value;
+    return (!valueAsFloat.isNaN() && !valueAsFloat.isInfinite());
   }
 
   private void sendAircraftHomeLocationEvent(Double latitude, Double longitude, Double altitude) {


### PR DESCRIPTION
### Summary

The home location altitude is being updated and sent repeatedly when the changes are usually within 0.25m. This level of precision isn't useful to us (and is erroneous any way) and ends up with our listener firing repeatedly. 

This is the updated flow:

![image](https://user-images.githubusercontent.com/56540191/126323904-9a76b9fe-14d7-4ab0-b587-85f268b50983.png)

It's a little messy in the code, but I tried to make a convenience method to neaten up the code at the expense of a little bit of code duplication. 

### Testing

✅  Tested with mobile app and the home location is not send repeatedly
✅  Analysed Logcat and the minor updates were not being sent