### PR TITLE
Fix/camera null pointer exception

### DIFF
--- a/android/src/main/java/com/aerobotics/DjiMobile/CameraEventDelegate.java
+++ b/android/src/main/java/com/aerobotics/DjiMobile/CameraEventDelegate.java
@@ -1,28 +1,15 @@
 package com.aerobotics.DjiMobile;
 
-import android.os.Handler;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import android.util.Log;
 
 import java.util.HashMap;
 import java.util.Observable;
 import java.util.Observer;
 
 import dji.common.camera.SystemState;
-import dji.common.error.DJIError;
-import dji.keysdk.CameraKey;
-import dji.keysdk.DJIKey;
-import dji.keysdk.KeyManager;
-import dji.keysdk.ProductKey;
-import dji.keysdk.callback.GetCallback;
-import dji.keysdk.callback.KeyListener;
-import dji.sdk.base.BaseProduct;
 import dji.sdk.camera.Camera;
 import dji.sdk.media.MediaFile;
-import dji.sdk.sdkmanager.DJISDKManager;
 
-// The CameraEventDelegate assumes that the app has successfully registered, otherwise things may crash!
 public class CameraEventDelegate implements SystemState.Callback, MediaFile.Callback {
 
   private class CameraEventObservable extends Observable {
@@ -33,57 +20,22 @@ public class CameraEventDelegate implements SystemState.Callback, MediaFile.Call
   }
 
   private CameraEventObservable cameraEventObservable = new CameraEventObservable();
-
-  private boolean isCameraConnected = false;
   private boolean callbacksSet = false;
-  private final CameraEventDelegate cameraDelegateSenderInstance = this;
 
-  private KeyListener CameraConnectedKeyListener = new KeyListener() {
-    @Override
-    public void onValueChange(@Nullable Object oldValue, @Nullable Object newValue) {
-      if (newValue != null && newValue instanceof Boolean) {
-        if ((boolean) newValue && !isCameraConnected) {
-          isCameraConnected = (boolean)newValue;
-          // When the SDK has just registered, calling getProduct may return null, so wait a second before trying
-          Handler handler = new Handler();
-          handler.postDelayed(new Runnable() {
-            @Override
-            public void run() {
-              cameraDelegateSenderInstance.setCameraCallbacks();
-            }
-          }, 1000);
-        }
-      }
-    }
-  };
-
-  CameraEventDelegate() {
-    boolean cameraConnected = isCameraConnected();
-    if (!cameraConnected) {
-      startCameraConnectionListener();
-    } else {
-      isCameraConnected = true;
-      setCameraCallbacks();
-    }
+  CameraEventDelegate(Camera camera) {
+    setCameraCallbacks(camera);
   }
 
-  private boolean isCameraConnected() {
-    BaseProduct product = DJISDKManager.getInstance().getProduct();
-    if (product == null) {
-      // cannot access the camera if the product is null
-      return false;
+  public void setCameraCallbacks(Camera camera) {
+    if (!callbacksSet) {
+      camera.setSystemStateCallback(this);
+      camera.setMediaFileCallback(this);
+      callbacksSet = true;
     }
-    Camera camera = product.getCamera();
-    return camera != null;
   }
 
   public boolean areCameraCallbacksSet() {
     return callbacksSet;
-  }
-
-  private void startCameraConnectionListener() {
-    KeyManager keyManager = DJISDKManager.getInstance().getKeyManager();
-    keyManager.addListener(CameraKey.create(CameraKey.CONNECTION), CameraConnectedKeyListener);
   }
 
   private void postEvent(SDKEvent sdkEvent, Object eventData) {
@@ -91,16 +43,6 @@ public class CameraEventDelegate implements SystemState.Callback, MediaFile.Call
     payload.put("eventType", sdkEvent);
     payload.put("value", eventData);
     cameraEventObservable.sendEvent(payload);
-  }
-
-  public void setCameraCallbacks() {
-    if (!callbacksSet) {
-      Camera camera = DJISDKManager.getInstance().getProduct().getCamera();
-      camera.setSystemStateCallback(this);
-      camera.setMediaFileCallback(this);
-      callbacksSet = true;
-    }
-
   }
 
   public void addObserver(Observer observer) {

--- a/android/src/main/java/com/aerobotics/DjiMobile/DJIMobile.java
+++ b/android/src/main/java/com/aerobotics/DjiMobile/DJIMobile.java
@@ -127,14 +127,16 @@ public class DJIMobile extends ReactContextBaseJavaModule {
       @Override
       public void onProductConnect(BaseProduct baseProduct) {
         product = baseProduct;
-        sdkEventHandler.initCameraEventDelegate();
       }
 
       @Override
-      public void onComponentChange(BaseProduct.ComponentKey componentKey, BaseComponent baseComponent, BaseComponent baseComponent1) {
-        // TODO
+      public void onComponentChange(BaseProduct.ComponentKey componentKey, BaseComponent oldBaseComponent, BaseComponent newBaseComponent) {
         if (startVisionControlStateListenerOnNextConnect) {
           startVisionControlStateListener();
+        }
+
+        if (newBaseComponent != null && newBaseComponent instanceof Camera) {
+          sdkEventHandler.initCameraEventDelegate((Camera) newBaseComponent);
         }
       }
 
@@ -541,7 +543,7 @@ public class DJIMobile extends ReactContextBaseJavaModule {
         promise.reject(new Throwable("Error camera not connected"));
         return;
       }
-      sdkEventHandler.setCameraCallbacks();
+      sdkEventHandler.setCameraCallbacks(camera);
     }
 
     startEventListener(SDKEvent.CameraDidGenerateNewMediaFile, new EventListener() {

--- a/android/src/main/java/com/aerobotics/DjiMobile/SdkEventHandler.java
+++ b/android/src/main/java/com/aerobotics/DjiMobile/SdkEventHandler.java
@@ -15,6 +15,7 @@ import dji.keysdk.DJIKey;
 import dji.keysdk.KeyManager;
 import dji.keysdk.callback.GetCallback;
 import dji.keysdk.callback.KeyListener;
+import dji.sdk.camera.Camera;
 import dji.sdk.sdkmanager.DJISDKManager;
 
 enum EventType {
@@ -37,8 +38,10 @@ public class SdkEventHandler {
     handler = new Handler(Looper.getMainLooper());
   }
 
-  public void initCameraEventDelegate() {
-    cameraEventDelegate = new CameraEventDelegate();
+  public void initCameraEventDelegate(Camera camera) {
+    if (cameraEventDelegate == null) {
+      cameraEventDelegate = new CameraEventDelegate(camera);
+    }
   }
 
   public boolean isCameraCallbacksInitialized() {
@@ -48,9 +51,11 @@ public class SdkEventHandler {
     return cameraEventDelegate.areCameraCallbacksSet();
   }
 
-  public void setCameraCallbacks() {
+  public void setCameraCallbacks(Camera camera) {
     if (cameraEventDelegate != null) {
-      cameraEventDelegate.setCameraCallbacks();
+      cameraEventDelegate.setCameraCallbacks(camera);
+    } else {
+      initCameraEventDelegate(camera);
     }
   }
 
@@ -80,16 +85,11 @@ public class SdkEventHandler {
               eventListener.onValueChange(null, payload);
             }
           }
-
         }
       };
-      if (cameraEventDelegate == null) {
-        cameraEventDelegate = new CameraEventDelegate();
-      }
       cameraEventDelegate.addObserver(observer);
       return observer;
     }
-
     return null;
   }
 


### PR DESCRIPTION
By passing the Camera class instance into the CameraEventDelegate it should prevent us from attempting to access a null object and removes the chance of race conditions