### PR TITLE
Add start and stop methods for DiagnosticsListener

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,6 +163,9 @@ const DJIMobileWrapper = {
   startVisionControlStateListener: startListener(DJIMobile.VisionControlState),
   stopVisionControlStateListener: stopListener(DJIMobile.VisionControlState),
 
+  startDiagnosticsListener: startListener(DJIMobile.DJIDiagnostics),
+  stopDiagnosticsListener: stopListener(DJIMobile.DJIDiagnostics),
+
   getAircraftLocation: async () => {
     return await DJIMobile.getAircraftLocation();
   },


### PR DESCRIPTION
Making starting and stopping the DiagnosticsListener available across the bridge. 