### PR TITLE
Aadd camera exposure settings callback

### DIFF
--- a/android/src/main/java/com/aerobotics/DjiMobile/SDKEvent.java
+++ b/android/src/main/java/com/aerobotics/DjiMobile/SDKEvent.java
@@ -58,6 +58,7 @@ public enum SDKEvent {
 
   CameraDidUpdateSystemState(null, EventType.DJI_CAMERA_DELEGATE_EVENT),
   CameraDidGenerateNewMediaFile(null, EventType.DJI_CAMERA_DELEGATE_EVENT),
+  CameraExposureSettings(CameraKey.create(CameraKey.EXPOSURE_SETTINGS), EventType.DJI_KEY_MANAGER_EVENT),
 
   VisionDetectionState(FlightControllerKey.createFlightAssistantKey(FlightControllerKey.VISION_DETECTION_STATE), EventType.DJI_KEY_MANAGER_EVENT),
   VisionControlState(null, EventType.DJI_CALLBACK_EVENT),

--- a/lib/CameraControl/index.js
+++ b/lib/CameraControl/index.js
@@ -146,7 +146,7 @@ const videoStandards = Object.freeze({
 });
 
 type ExposureCompensationValues = '-5.0' | '-4.7' | '-4.3' | '-4.0' | '-3.7' | '-3.3' | '-3.0' | '-2.7' | '-2.3' | '-2.0' | '-1.7' | '-1.3' | '-1.0' | '-0.7' | '-0.3' | '0.0' | '0.3' | '0.7' | '1.0' | '1.3' | '1.7' | '2.0' | '2.3' | '2.7' | '3.0' | '3.3' | '3.7' | '4.0' | '5.0' | 'FIXED'
-const exposureCompensationValues = Object.freeze({
+export const exposureCompensationValues = Object.freeze({
   '-5.0': 'N_5_0',
   '-4.7': 'N_4_7',
   '-4.3': 'N_4_3',


### PR DESCRIPTION
Add ability to subscribe to camera exposure settings events using the callback exposed by `CameraKey.EXPOSURE_SETTINGS`. 