### PR TITLE
perf: only send diagnostics event if diagnostics update

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -202,6 +202,7 @@ const DJIMobileWrapper = {
     return DJIEventSubject.pipe($filter(evt => evt.type === 'DJIDiagnostics'));
   },
   startDiagnosticsListenerV2: async () => {
+    await DJIMobile.resetPreviousDiagnostics();
     return observeEvent<DJIDiagnostic[]>('DJIDiagnostics');
   },
 


### PR DESCRIPTION
Previously, we were only not sending events when the diagnostics array was empty. However, this was a bug because if there were diagnostics, and then there were none, it wouldn't send the empty diagnostics array. 

Since diagnostics are updated every second or so, this ensures that only the updates with changed values are sent as events over the bridge. 

### Testing
✅  tested with Phantom & M210V1

@MikeWoots merging. 