### PR TITLE
Add more pre-flight check listeners

### DIFF
--- a/android/src/main/java/com/aerobotics/DjiMobile/DJIMobile.java
+++ b/android/src/main/java/com/aerobotics/DjiMobile/DJIMobile.java
@@ -934,25 +934,50 @@ public class DJIMobile extends ReactContextBaseJavaModule {
   }
 
   private void startRemoteControllerFlightModeListener() {
+    getInitialSDKEventValue(SDKEvent.RemoteControllerFlightMode, new GetCallbackWrapper() {
+      @Override
+      public void onSuccess(@NonNull Object o) {
+        handleRemoteControllerFlightModeUpdate(o, true);
+      }
+    });
     startEventListener(SDKEvent.RemoteControllerFlightMode, new EventListener() {
       @Override
       public void onValueChange(@Nullable Object oldValue, @Nullable Object newValue) {
-        if (newValue != null && newValue instanceof RemoteControllerFlightMode) {
-          sendEvent(SDKEvent.RemoteControllerFlightMode, ((RemoteControllerFlightMode)newValue).name());
-        }
+        handleRemoteControllerFlightModeUpdate(newValue, false);
       }
     });
   }
 
+  private void handleRemoteControllerFlightModeUpdate(@Nullable Object newValue, Boolean realtime) {
+    if (newValue != null && newValue instanceof RemoteControllerFlightMode) {
+      this.eventSender.processEvent(
+        SDKEvent.RemoteControllerFlightMode,
+        ((RemoteControllerFlightMode)newValue).name(),
+        realtime
+      );
+    }
+  }
+
   private void startCompassHasErrorListener() {
+    getInitialSDKEventValue(SDKEvent.CompassHasError, new GetCallbackWrapper() {
+      @Override
+      public void onSuccess(@NonNull Object o) {
+        handleCompassHasErrorUpdate(o, true);
+      }
+    });
+
     startEventListener(SDKEvent.CompassHasError, new EventListener() {
       @Override
       public void onValueChange(@Nullable Object oldValue, @Nullable Object newValue) {
-        if (newValue instanceof Boolean) {
-          sendEvent(SDKEvent.CompassHasError, newValue);
-        }
+        handleCompassHasErrorUpdate(newValue, false);
       }
     });
+  }
+
+  private void handleCompassHasErrorUpdate(@Nullable Object newValue, Boolean realtime) {
+    if (newValue != null && newValue instanceof Boolean) {
+      this.eventSender.processEvent(SDKEvent.CompassHasError, newValue, realtime);
+    }
   }
 
   private void startIsRecordingListener() {
@@ -1000,16 +1025,26 @@ public class DJIMobile extends ReactContextBaseJavaModule {
   }
 
   private void startCameraWhiteBalanceListener() {
+    getInitialSDKEventValue(SDKEvent.CameraWhiteBalance, new GetCallbackWrapper() {
+      @Override
+      public void onSuccess(@NonNull Object o) {
+        handleCameraWhiteBalanceUpdate(o, true);
+      }
+    });
     startEventListener(SDKEvent.CameraWhiteBalance, new EventListener() {
       @Override
       public void onValueChange(@Nullable Object oldValue, @Nullable Object newValue) {
-        if (newValue instanceof WhiteBalance) {
-          WhiteBalance whiteBalance = (WhiteBalance)newValue;
-          SettingsDefinitions.WhiteBalancePreset preset = whiteBalance.getWhiteBalancePreset();
-          sendEvent(SDKEvent.CameraWhiteBalance, preset.name());
-        }
+        handleCameraWhiteBalanceUpdate(newValue, false);
       }
     });
+  }
+
+  private void handleCameraWhiteBalanceUpdate(@Nullable Object newValue, Boolean realtime) {
+    if (newValue != null && newValue instanceof WhiteBalance) {
+      WhiteBalance whiteBalance = (WhiteBalance)newValue;
+      SettingsDefinitions.WhiteBalancePreset preset = whiteBalance.getWhiteBalancePreset();
+      this.eventSender.processEvent(SDKEvent.CameraWhiteBalance, preset.name(), realtime);
+    }
   }
 
   private void startVirtualStickEnabledListener() {
@@ -1046,14 +1081,24 @@ public class DJIMobile extends ReactContextBaseJavaModule {
   }
 
   private void startSDCardAvailableCaptureCountListener() {
+    getInitialSDKEventValue(SDKEvent.SDCardAvailableCaptureCount, new GetCallbackWrapper() {
+      @Override
+      public void onSuccess(@NonNull Object o) {
+        handleSDCardAvailableCaptureCountUpdate(o, true);
+      }
+    });
     startEventListener(SDKEvent.SDCardAvailableCaptureCount, new EventListener() {
       @Override
       public void onValueChange(@Nullable Object oldValue, @Nullable Object newValue) {
-        if (newValue instanceof Long) {
-          sendEvent(SDKEvent.SDCardAvailableCaptureCount, newValue);
-        }
+        handleSDCardAvailableCaptureCountUpdate(newValue, false);
       }
     });
+  }
+
+  private void handleSDCardAvailableCaptureCountUpdate(@Nullable Object newValue, Boolean realtime) {
+    if (newValue != null && newValue instanceof Long) {
+      this.eventSender.processEvent(SDKEvent.SDCardAvailableCaptureCount, newValue, realtime);
+    }
   }
 
   private void startGimbalIsAtYawStopListener() {
@@ -1337,7 +1382,26 @@ public class DJIMobile extends ReactContextBaseJavaModule {
     }
   }
 
-    @ReactMethod
+  interface GetCallbackWrapper {
+    void onSuccess(@NonNull Object o);
+  }
+
+  private void getInitialSDKEventValue(final SDKEvent sdkEvent,final GetCallbackWrapper callback) {
+    DJIKey key = (DJIKey) sdkEvent.getKey();
+    DJISDKManager.getInstance().getKeyManager().getValue(key, new GetCallback() {
+      @Override
+      public void onSuccess(@NonNull Object o) {
+        callback.onSuccess(o);
+      }
+
+      @Override
+      public void onFailure(@NonNull DJIError djiError) {
+        Log.e("REACT", "Could not get inital value of " + sdkEvent.name() + ": " + djiError.getDescription());
+      }
+    });
+  }
+
+  @ReactMethod
     public void limitEventFrequency(double newEventSendFrequencyInHz, Promise promise) {
       int milliSecs = (int) Math.round((1/newEventSendFrequencyInHz) * 1000);
       this.eventSender.setNewEventSendFrequency(milliSecs);

--- a/android/src/main/java/com/aerobotics/DjiMobile/EventSender.java
+++ b/android/src/main/java/com/aerobotics/DjiMobile/EventSender.java
@@ -74,6 +74,8 @@ public class EventSender {
             params.putInt("value", (Integer)value);
         } else if (value instanceof Double) {
             params.putDouble("value", (Double) value);
+        } else if (value instanceof Long) {
+            params.putDouble("value", ((Long) value).doubleValue());
         } else if (value instanceof String) {
             params.putString("value", (String)value);
         } else if (value instanceof Boolean) {

--- a/android/src/main/java/com/aerobotics/DjiMobile/SDKEvent.java
+++ b/android/src/main/java/com/aerobotics/DjiMobile/SDKEvent.java
@@ -26,6 +26,8 @@ public enum SDKEvent {
   AircraftAttitudeRoll(FlightControllerKey.create(FlightControllerKey.ATTITUDE_ROLL), EventType.DJI_KEY_MANAGER_EVENT),
 
   AircraftGpsSignalLevel(FlightControllerKey.create(FlightControllerKey.GPS_SIGNAL_LEVEL), EventType.DJI_KEY_MANAGER_EVENT),
+  SatelliteCount(FlightControllerKey.create(FlightControllerKey.SATELLITE_COUNT), EventType.DJI_KEY_MANAGER_EVENT),
+
   AirLinkUplinkSignalQuality(null, EventType.DJI_KEY_MANAGER_EVENT),
   AirLinkLightbridgeUplinkSignalQuality(AirLinkKey.createLightbridgeLinkKey(AirLinkKey.UPLINK_SIGNAL_QUALITY), EventType.DJI_KEY_MANAGER_EVENT),
   AirLinkOcuSyncUplinkSignalQuality(AirLinkKey.createOcuSyncLinkKey(AirLinkKey.UPLINK_SIGNAL_QUALITY), EventType.DJI_KEY_MANAGER_EVENT),
@@ -37,17 +39,24 @@ public enum SDKEvent {
   TakeoffLocationAltitude(FlightControllerKey.create(FlightControllerKey.TAKEOFF_LOCATION_ALTITUDE), EventType.DJI_KEY_MANAGER_EVENT),
   AircraftUltrasonicHeight(FlightControllerKey.create(FlightControllerKey.ULTRASONIC_HEIGHT_IN_METERS), EventType.DJI_KEY_MANAGER_EVENT),
   CompassHasError(FlightControllerKey.create(FlightControllerKey.COMPASS_HAS_ERROR), EventType.DJI_KEY_MANAGER_EVENT),
+  IMUSensorState(FlightControllerKey.create(FlightControllerKey.IMU_STATE), EventType.DJI_KEY_MANAGER_EVENT),
 
   LandingProtectionEnabled(FlightControllerKey.create(FlightControllerKey.LANDING_PROTECTION_ENABLED), EventType.DJI_KEY_MANAGER_EVENT),
   VisionAssistedPositioningEnabled(FlightControllerKey.create(FlightControllerKey.VISION_ASSISTED_POSITIONING_ENABLED), EventType.DJI_KEY_MANAGER_EVENT),
+  RemoteControllerFlightMode(FlightControllerKey.create(FlightControllerKey.CURRENT_MODE), EventType.DJI_KEY_MANAGER_EVENT),
 
-  CameraIsRecording(CameraKey.create(CameraKey.IS_RECORDING), EventType.DJI_KEY_MANAGER_EVENT),
+  // Camera & SD Card Events
   SDCardIsInserted(CameraKey.create(CameraKey.SDCARD_IS_INSERTED), EventType.DJI_KEY_MANAGER_EVENT),
   SDCardIsReadOnly(CameraKey.create(CameraKey.SDCARD_IS_READ_ONLY), EventType.DJI_KEY_MANAGER_EVENT),
-
+  SDCardAvailableCaptureCount(CameraKey.create(CameraKey.SDCARD_AVAILABLE_CAPTURE_COUNT), EventType.DJI_KEY_MANAGER_EVENT),
+  CameraIsRecording(CameraKey.create(CameraKey.IS_RECORDING), EventType.DJI_KEY_MANAGER_EVENT),
   CameraIsShootingSinglePhoto(CameraKey.create(CameraKey.IS_SHOOTING_SINGLE_PHOTO), EventType.DJI_KEY_MANAGER_EVENT),
   CameraIsStoringPhoto(CameraKey.create(CameraKey.IS_STORING_PHOTO), EventType.DJI_KEY_MANAGER_EVENT),
   CameraIsShootingPhoto(CameraKey.create(CameraKey.IS_SHOOTING_PHOTO), EventType.DJI_KEY_MANAGER_EVENT),
+  CameraDidUpdateSystemState(null, EventType.DJI_CAMERA_DELEGATE_EVENT),
+  CameraDidGenerateNewMediaFile(null, EventType.DJI_CAMERA_DELEGATE_EVENT),
+  CameraExposureSettings(CameraKey.create(CameraKey.EXPOSURE_SETTINGS), EventType.DJI_KEY_MANAGER_EVENT),
+  CameraWhiteBalance(CameraKey.create(CameraKey.WHITE_BALANCE), EventType.DJI_KEY_MANAGER_EVENT),
 
   GimbalIsAtYawStop(GimbalKey.create(GimbalKey.IS_YAW_AT_STOP), EventType.DJI_KEY_MANAGER_EVENT),
 
@@ -62,10 +71,6 @@ public enum SDKEvent {
   AircraftVirtualStickEnabled(FlightControllerKey.create(FlightControllerKey.VIRTUAL_STICK_CONTROL_MODE_ENABLED), EventType.DJI_KEY_MANAGER_EVENT),
 
   OnboardSDKDeviceData(null, EventType.DJI_ONBOARD_SDK_DEVICE_DATA_EVENT),
-
-  CameraDidUpdateSystemState(null, EventType.DJI_CAMERA_DELEGATE_EVENT),
-  CameraDidGenerateNewMediaFile(null, EventType.DJI_CAMERA_DELEGATE_EVENT),
-  CameraExposureSettings(CameraKey.create(CameraKey.EXPOSURE_SETTINGS), EventType.DJI_KEY_MANAGER_EVENT),
 
   VisionDetectionState(FlightControllerKey.createFlightAssistantKey(FlightControllerKey.VISION_DETECTION_STATE), EventType.DJI_KEY_MANAGER_EVENT),
   VisionControlState(null, EventType.DJI_CALLBACK_EVENT),

--- a/lib/utilities/parseExposureSettings.ts
+++ b/lib/utilities/parseExposureSettings.ts
@@ -1,0 +1,9 @@
+import { CameraExposureSettings } from '../../types'
+import { exposureCompensationValues } from '../CameraControl'
+
+export const parseExposureSettings = (value: CameraExposureSettings) => {
+  return {
+    ...value,
+    exposureValue: parseFloat(Object.keys(exposureCompensationValues).find(key => exposureCompensationValues[key] === value.exposureValue)),
+  }
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -92,3 +92,48 @@ export interface DJIDiagnostic {
   solution: string;
   error: string;
 }
+
+export type SensorState =
+  | "UNKNOWN"
+  | "DISCONNECTED"
+  | "CALIBRATING"
+  | "CALIBRATION_FAILED"
+  | "DATA_EXCEPTION"
+  | "WARMING_UP"
+  | "IN_MOTION"
+  | "NORMAL_BIAS"
+  | "MEDIUM_BIAS"
+  | "LARGE_BIAS"
+
+export interface IMUState {
+  accelerometerState: SensorState;
+  gyroscopeState: SensorState;
+}
+
+export type WhiteBalancePresets =
+  | "AUTO"
+  | "SUNNY"
+  | "CLOUDY"
+  | "WATER_SURFACE"
+  | "INDOOR_INCANDESCENT"
+  | "INDOOR_FLUORESCENT"
+  | "CUSTOM"
+  | "PRESET_NEUTRAL"
+  | "UNKNOWN"
+
+export type CameraExposureSettings = {
+  aperture?: number;
+  iso?: number;
+  shutterSpeed?: number;
+  exposureValue?: number;
+};
+
+export type RemoteControllerFlightMode =
+  | "F"
+  | "A"
+  | "P"
+  | "S"
+  | "G"
+  | "M"
+  | "T"
+  | "UNKNOWN"


### PR DESCRIPTION
Added a bunch of listeners which are useful for pre-flight checks. 

~I am facing the problem of a stale observable when the observer subscribes after the subject has start emitting values, so I still need to add get methods when the observer is initialised.~ Resolved

✅ tested all additions