### PR TITLE
Fix: Mission state updates

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -59,6 +59,7 @@ export interface WaypointMissionExecutionProgressEvent {
   targetWaypointIndex: number;
   isWaypointReached: boolean;
   executeState: WaypointMissionExecuteState;
+  totalWaypointCount: number;
 }
 
 export interface WaypointMissionUploadEvent {


### PR DESCRIPTION
### Summary
* use the `WaypointMissionOperator` as the source of truth for all state updates
* don't send updates `onResult` since the updates are already sent in the various `on*Update` callbacks

#### Other
* add a missing field to the waypoint mission progress - total waypoints count. Makes the downstream logic far simpler!

### Testing
✅  I've flown a bunch of missions and analysed the logs closely